### PR TITLE
Drop `pandas` add `pendulum`; it's less overkill

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     package_dir={'':'src'},
     install_requires=[
         'numpy',
-        'pandas',
+        'pendulum',
         'purerpc'
     ]
 )

--- a/src/anyio_marketstore/params.py
+++ b/src/anyio_marketstore/params.py
@@ -1,19 +1,18 @@
 from typing import Union, List, Any
-# import pendulum
-import pandas as pd
+import pendulum
 import numpy as np
 from enum import Enum
 
 
-def get_timestamp(value: Union[float, int, str]) -> pd.Timestamp:
+def get_timestamp(value: Union[float, int, str]) -> pendulum.DateTime:
 
     if value is None:
         return None
 
     if isinstance(value, (float, np.float, int, np.integer)):
-        return pd.Timestamp(value, unit='s')
+        return pendulum.from_timestamp(value)
 
-    return pd.Timestamp(value)
+    return pendulum.parse(value)
 
 
 def isiterable(something: Any) -> bool:

--- a/src/anyio_marketstore/results.py
+++ b/src/anyio_marketstore/results.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 import numpy as np
-import pandas as pd
+# import pandas as pd
 import six
 
 from .proto.marketstore_pb2 import MultiQueryResponse
@@ -68,15 +68,15 @@ class DataSet(object):
     def attribute_group(self) -> str:
         return self.key.split('/')[2]
 
-    def df(self) -> pd.DataFrame:
-        idxname = self.array.dtype.names[0]
-        df = pd.DataFrame(self.array).set_index(idxname)
-        index = pd.to_datetime(df.index, unit='s', utc=True)
-        tz = self.timezone
-        if tz.lower() != 'utc':
-            index = index.tz_convert(tz)
-        df.index = index
-        return df
+    # def df(self) -> pd.DataFrame:
+    #     idxname = self.array.dtype.names[0]
+    #     df = pd.DataFrame(self.array).set_index(idxname)
+    #     index = pd.to_datetime(df.index, unit='s', utc=True)
+    #     tz = self.timezone
+    #     if tz.lower() != 'utc':
+    #         index = index.tz_convert(tz)
+    #     df.index = index
+    #     return df
 
     def __repr__(self):
         a = self.array


### PR DESCRIPTION
Only using it for `pandas.Timestamp` is kinda silly, so just use the
friendly `pendulum` for datetimes instead. Required a slight rework of
nanosecond calcs using `divmod()`.