### PR TITLE
`numpy.float` is deprecated and removed on python 3.11

### DIFF
--- a/src/anyio_marketstore/params.py
+++ b/src/anyio_marketstore/params.py
@@ -9,7 +9,7 @@ def get_timestamp(value: Union[float, int, str]) -> pendulum.DateTime:
     if value is None:
         return None
 
-    if isinstance(value, (float, np.float, int, np.integer)):
+    if isinstance(value, (float, float, int, np.integer)):
         return pendulum.from_timestamp(value)
 
     return pendulum.parse(value)


### PR DESCRIPTION
Pretty sure that's the only one?

Required to land https://github.com/pikers/piker/pull/506